### PR TITLE
Added graphql-kotlin server logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # Example Ktor API (Gradle, Kotlin, GraphQL Project)
 
+## Usage
+Vist `localhost:8088/playground` to query the graphQL API.
+At the moment it only supports
+```
+query {
+  hello
+}
+```
+Another option is to curl a POST request to `localhost:8088/graphql` with the following
+body
+```
+curl -X POST 'http://0.0.0.0:8088/graphql' \
+-H 'Content-Type: application/json' \
+--data-raw '{"query":"query {hello}\n","variables":{}}'
+```
+
 ## Using Gradle
 ```
 # To run tests for a project, Gradle will not run tests for area's that have not had any changes.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ val logbackVersion: String by project
 val ktorVersion: String by project
 val kotlinVersion: String by project
 val loggingWrapperVersion: String by project
+val graphqlKotlinVersion: String by project
 
 plugins {
     application
@@ -40,6 +41,11 @@ dependencies {
     // Kotest framework and assertion
     testImplementation("io.kotest:kotest-runner-junit5:4.4.1")
     testImplementation("io.kotest:kotest-assertions-core:4.4.1")
+
+    // Schema Generator
+    implementation("com.expediagroup:graphql-kotlin-schema-generator:$graphqlKotlinVersion")
+    implementation("com.expediagroup:graphql-kotlin-types:$graphqlKotlinVersion")
+    implementation("com.expediagroup:graphql-kotlin-server:$graphqlKotlinVersion")
 }
 
 tasks.withType<KotlinCompile> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ ktorVersion=1.5.2
 kotlin.code.style=official
 kotlinVersion=1.4.30
 loggingWrapperVersion=1.7.9
+graphqlKotlinVersion=4.0.0-alpha.14

--- a/src/main/kotlin/com/graphql/example/Application.kt
+++ b/src/main/kotlin/com/graphql/example/Application.kt
@@ -1,4 +1,4 @@
-package com.example
+package com.graphql.example
 
 import io.ktor.application.*
 import io.ktor.response.*

--- a/src/main/kotlin/com/graphql/example/Context.kt
+++ b/src/main/kotlin/com/graphql/example/Context.kt
@@ -1,0 +1,13 @@
+package com.graphql.example
+
+import com.expediagroup.graphql.generator.execution.GraphQLContext
+import java.util.*
+
+/*
+ * Example of a custom GraphQLContext which will be created for every request and be used during execution.
+ */
+data class Context(
+    val customHeader: String? = null
+) : GraphQLContext {
+    val uuid: UUID = UUID.randomUUID();
+}

--- a/src/main/kotlin/com/graphql/example/GraphQLModule.kt
+++ b/src/main/kotlin/com/graphql/example/GraphQLModule.kt
@@ -1,0 +1,26 @@
+package com.graphql.example
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+
+fun Application.graphQLModule() {
+    install(Routing)
+
+    routing {
+        post("graphql") {
+            KtorServer().handle(this.call)
+        }
+
+        get("playground") {
+            this.call.respondText(buildPlaygroundHtml("graphql", "subscriptions"), ContentType.Text.Html)
+        }
+    }
+}
+
+private fun buildPlaygroundHtml(graphQLEndpoint: String, subscriptionsEndpoint: String) =
+    Application::class.java.classLoader.getResource("graphql-playground.html")?.readText()
+        ?.replace("\${graphQLEndpoint}", graphQLEndpoint)
+        ?.replace("\${subscriptionsEndpoint}", subscriptionsEndpoint)
+        ?: throw IllegalStateException("graphql-playground.html cannot be found in the classpath")

--- a/src/main/kotlin/com/graphql/example/KtorGraphQLContextFactory.kt
+++ b/src/main/kotlin/com/graphql/example/KtorGraphQLContextFactory.kt
@@ -1,0 +1,16 @@
+package com.graphql.example
+
+import com.expediagroup.graphql.server.execution.GraphQLContextFactory
+import io.ktor.request.*
+
+/**
+ *  This factory will create a GraphQLContext for every http request containing properties of Context class
+ */
+class KtorGraphQLContextFactory: GraphQLContextFactory<Context, ApplicationRequest> {
+    override suspend fun generateContext(request: ApplicationRequest): Context? {
+        val customHeader: String? = request.headers["customer-header"]
+
+        return Context(customHeader)
+    }
+
+}

--- a/src/main/kotlin/com/graphql/example/ktorGraphQLRequestParser.kt
+++ b/src/main/kotlin/com/graphql/example/ktorGraphQLRequestParser.kt
@@ -1,0 +1,36 @@
+package com.graphql.example
+
+import com.expediagroup.graphql.server.execution.GraphQLBatchRequest
+import com.expediagroup.graphql.server.execution.GraphQLRequestParser
+import com.expediagroup.graphql.server.execution.GraphQLServerRequest
+import com.expediagroup.graphql.server.execution.GraphQLSingleRequest
+import com.expediagroup.graphql.types.GraphQLRequest
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.request.*
+import java.io.IOException
+
+/*
+ * Logic to parse incoming ktor http request into a GraphQLServerRequest
+ * Allows for the handling of single and batch requests while validating the shape of the request
+ */
+class KtorGraphQLRequestParser(
+    private val mapper: ObjectMapper
+) : GraphQLRequestParser<ApplicationRequest> {
+
+    private val graphQLBatchRequestTypeReference: TypeReference<List<GraphQLRequest>> = object : TypeReference<List<GraphQLRequest>>() {}
+
+    @Suppress("BlockingMethodInNonBlockingContext")
+    override suspend fun parseRequest(request: ApplicationRequest): GraphQLServerRequest<*> = try {
+        val rawRequest = request.call.receiveText()
+        val jsonNode = mapper.readTree(rawRequest)
+        if (jsonNode.isArray) {
+            GraphQLBatchRequest(mapper.convertValue(jsonNode, graphQLBatchRequestTypeReference))
+        } else {
+            GraphQLSingleRequest(mapper.treeToValue(jsonNode, GraphQLRequest::class.java))
+        }
+    } catch (e: IOException) {
+        throw IOException("Unable to parse GraphQL payload.")
+    }
+
+}

--- a/src/main/kotlin/com/graphql/example/ktorGraphQLSchema.kt
+++ b/src/main/kotlin/com/graphql/example/ktorGraphQLSchema.kt
@@ -1,0 +1,19 @@
+package com.graphql.example
+
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.toSchema
+import com.graphql.example.schema.HelloQueryService
+import graphql.GraphQL
+
+private val config = SchemaGeneratorConfig(supportedPackages = listOf("com.graphql.example"))
+private val queries = listOf(
+    TopLevelObject(HelloQueryService())
+)
+
+// Any public functions defined on query Kotlin class will be translated into GQL fields on the obj type.
+// toSchema will then recursively applu Kotlin reflection on the specified classes
+private val graphQLSchema = toSchema(config, queries)
+
+// Our root access to query GQL
+val graphQL: GraphQL = GraphQL.newGraphQL(graphQLSchema).build()

--- a/src/main/kotlin/com/graphql/example/ktorGraphQLServer.kt
+++ b/src/main/kotlin/com/graphql/example/ktorGraphQLServer.kt
@@ -1,0 +1,27 @@
+package com.graphql.example
+
+import com.expediagroup.graphql.server.execution.GraphQLRequestHandler
+import com.expediagroup.graphql.server.execution.GraphQLServer
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.request.*
+
+/**
+ * Helper method for how Ktor creates the common [GraphQLServer] object that can handle requests.
+ *
+ * @param requestParser Parse the GraphQL request info from the HTTP request
+ * @param contextFactory Create a GraphQLContext object from the HTTP request to be used during execution
+ * @param requestHandler Send the request and the context to the GraphQL schema to execute and get a response
+ */
+class KtorGraphQLServer (
+    requestParser: KtorGraphQLRequestParser,
+    contextFactory: KtorGraphQLContextFactory,
+    requestHandler: GraphQLRequestHandler
+): GraphQLServer<ApplicationRequest>(requestParser, contextFactory, requestHandler)
+
+fun getGraphQLServer(mapper: ObjectMapper): KtorGraphQLServer {
+    val requestParser = KtorGraphQLRequestParser(mapper)
+    val contextFactory = KtorGraphQLContextFactory()
+    val requestHandler = GraphQLRequestHandler(graphQL, null)
+
+    return KtorGraphQLServer(requestParser, contextFactory, requestHandler)
+}

--- a/src/main/kotlin/com/graphql/example/ktorServer.kt
+++ b/src/main/kotlin/com/graphql/example/ktorServer.kt
@@ -1,0 +1,33 @@
+package com.graphql.example
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+
+/**
+ * The Ktor specific code to handle incoming [ApplicationCall]s, send them to GraphQL,
+ * and then format and send a correct response back.
+ */
+
+class KtorServer {
+    private val mapper = jacksonObjectMapper()
+    private val ktorGraphQLServer = getGraphQLServer(mapper)
+
+    /**
+     * Handle incoming Ktor Http requests and send them back to the response methods.
+     */
+    @Suppress("BlockingMethodInNonBlockingContext")
+    suspend fun handle(applicationCall: ApplicationCall) {
+        // Execute the query against the schema which will return a GQL response
+        val result = ktorGraphQLServer.execute(applicationCall.request)
+
+        if (result != null) {
+            // write response as json
+            val json = mapper.writeValueAsString(result.response)
+            applicationCall.response.call.respond(json)
+        } else {
+            applicationCall.response.call.respond(HttpStatusCode.BadRequest, "Invalid request")
+        }
+    }
+}

--- a/src/main/kotlin/com/graphql/example/schema/HelloQueryService.kt
+++ b/src/main/kotlin/com/graphql/example/schema/HelloQueryService.kt
@@ -1,0 +1,7 @@
+package com.graphql.example.schema
+
+import com.expediagroup.graphql.types.operations.Query
+
+class HelloQueryService: Query {
+    fun hello() = "World!"
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,11 +1,11 @@
 ktor {
     deployment {
-        port = 8080
+        port = 8088
         port = ${?PORT}
         watch = [ classes ]
     }
     application {
-        modules = [ com.example.ApplicationKt.module ]
+        modules = [ com.graphql.example.GraphQLModuleKt.graphQLModule ]
     }
     development = true
 }

--- a/src/main/resources/graphql-playground.html
+++ b/src/main/resources/graphql-playground.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset=utf-8/>
+    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+    <title>GraphQL Playground</title>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
+    <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+    <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+</head>
+
+<body>
+<div id="root">
+    <style>
+        body {
+            background-color: rgb(23, 42, 58);
+            font-family: Open Sans, sans-serif;
+            height: 90vh;
+        }
+
+        #root {
+            height: 100%;
+            width: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .loading {
+            font-size: 32px;
+            font-weight: 200;
+            color: rgba(255, 255, 255, .6);
+            margin-left: 20px;
+        }
+
+        img {
+            width: 78px;
+            height: 78px;
+        }
+
+        .title {
+            font-weight: 400;
+        }
+    </style>
+    <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
+    <div class="loading"> Loading
+        <span class="title">GraphQL Playground</span>
+    </div>
+</div>
+<script>window.addEventListener('load', function (event) {
+    GraphQLPlayground.init(document.getElementById('root'), {
+        settings: {'request.credentials': 'same-origin'},
+        endpoint: '/${graphQLEndpoint}',
+        subscriptionEndpoint: '/${subscriptionsEndpoint}'
+    })
+})</script>
+</body>
+
+</html>


### PR DESCRIPTION
Using the graphql-kotlin library, I have created a basic graphql server that can be queried using a hello world example.

This change also includes an interactive "playground" from the official docs, that allows for generation and execution of gql queries similar to how graphlQLi on javascript.